### PR TITLE
Fix: Make player visible by setting depth

### DIFF
--- a/scenes/player/Player.js
+++ b/scenes/player/Player.js
@@ -2,6 +2,9 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     constructor(scene, x, y, texture, frame) {
         super(scene, x, y, texture, frame);
 
+        // Baldur's Gate 3 style means top down view, so we need to make sure the player is rendered on top of the map.
+        this.setDepth(1);
+
         this.character = {
             name: "Hero",
             level: 1,


### PR DESCRIPTION
The player sprite was not visible because it was being rendered underneath the tilemap.

This change sets the player's depth to 1 in the `Player` class constructor, ensuring it is rendered on top of the tilemap (which has a default depth of 0). This is a common solution for layering issues in Phaser and aligns with the "Baldur's Gate 3 style" top-down perspective mentioned in the issue.